### PR TITLE
fix url issue to image upload

### DIFF
--- a/bms_frontend/.env.development
+++ b/bms_frontend/.env.development
@@ -1,7 +1,3 @@
-# Default local fallback.
-# Local dev uses .env.development.
-# AWS production build uses .env.production.
-
 VITE_FRONTEND_URL=https://192.168.68.66:5173
 
 VITE_KEYCLOAK_URL=https://bms-auth.test

--- a/bms_frontend/.env.production
+++ b/bms_frontend/.env.production
@@ -1,5 +1,9 @@
-VITE_API_BASE_URL=https://bms.qbitlabsbms.com/api
+VITE_FRONTEND_URL=https://bms.qbitlabsbms.com
 
 VITE_KEYCLOAK_URL=https://bms.qbitlabsbms.com/auth
 VITE_KEYCLOAK_REALM=bms
 VITE_KEYCLOAK_CLIENT_ID=bms-frontend
+
+VITE_API_BASE_URL=https://bms.qbitlabsbms.com
+VITE_WS_BASE_URL=https://bms.qbitlabsbms.com/ws
+VITE_BACKEND_PROXY_TARGET=https://bms.qbitlabsbms.com


### PR DESCRIPTION
This PR fixes the frontend production environment configuration for AWS deployment.

Changes:
- Added .env.development for local development URLs.
- Updated .env.production to use the AWS production domain.
- Set production API base URL to https://bms.qbitlabsbms.com.
- Set production WebSocket URL to https://bms.qbitlabsbms.com/ws.
- Prevents the AWS frontend build from using local bms-api.test and bms-auth.test URLs.

Reason:
The deployed AWS frontend was still trying to connect to the local development WebSocket endpoint:
https://bms-api.test/ws/info

This caused WebSocket connection failures in production and affected technician message/photo reply workflows.