### PR TITLE
Fix production frontend Nginx configuration

### DIFF
--- a/bms_frontend/Dockerfile
+++ b/bms_frontend/Dockerfile
@@ -15,11 +15,12 @@ COPY . .
 
 RUN yarn build
 
+
 FROM nginx:1.27-alpine
 
-RUN rm /etc/nginx/conf.d/default.conf
+RUN rm -f /etc/nginx/conf.d/default.conf
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx/default.prod.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
 EXPOSE 80

--- a/bms_frontend/docker-compose.yml
+++ b/bms_frontend/docker-compose.yml
@@ -10,3 +10,4 @@ services:
       - "3000:443"
     volumes:
       - ./certs:/etc/nginx/certs:ro
+      - ./nginx/default.local.conf:/etc/nginx/conf.d/default.conf:ro

--- a/bms_frontend/nginx/default.local.conf
+++ b/bms_frontend/nginx/default.local.conf
@@ -1,0 +1,20 @@
+server {
+    listen 443 ssl;
+    server_name bms-frontend.test localhost 192.168.1.52;
+
+    ssl_certificate /etc/nginx/certs/bms-frontend.test.pem;
+    ssl_certificate_key /etc/nginx/certs/bms-frontend.test-key.pem;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "healthy\n";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/bms_frontend/nginx/default.prod.conf
+++ b/bms_frontend/nginx/default.prod.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "healthy\n";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the AWS frontend container restart and 502 Bad Gateway error.

## Changes

- Added separate local and production Nginx configurations
- Kept HTTPS certificates only for local development
- Configured the production container to listen on HTTP port 80
- Removed production dependency on local `.test.pem` certificates
- Added frontend health endpoint support

## Deployment issue fixed

The production image previously expected:

- `/etc/nginx/certs/bms-frontend.test.pem`
- `/etc/nginx/certs/bms-frontend.test-key.pem`

These local certificates were not available in AWS, causing the frontend container to restart continuously.